### PR TITLE
[WIP] Added tag for 2.3 compatibility with decorators

### DIFF
--- a/CmfCoreBundle.php
+++ b/CmfCoreBundle.php
@@ -15,12 +15,14 @@ use Symfony\Component\HttpKernel\Bundle\Bundle;
 use Symfony\Component\DependencyInjection\ContainerBuilder;
 use Symfony\Cmf\Bundle\CoreBundle\DependencyInjection\Compiler\RequestAwarePass;
 use Symfony\Cmf\Bundle\CoreBundle\DependencyInjection\Compiler\AddPublishedVotersPass;
+use Symfony\Cmf\Bundle\CoreBundle\DependencyInjection\Compiler\DecoratorCompatibilityPass;
 
 class CmfCoreBundle extends Bundle
 {
     public function build(ContainerBuilder $container)
     {
         $container->addCompilerPass(new RequestAwarePass());
+        $container->addCompilerPass(new DecoratorCompatibilityPass());
         $container->addCompilerPass(new AddPublishedVotersPass());
     }
 }

--- a/DependencyInjection/Compiler/DecoratorCompatibilityPass.php
+++ b/DependencyInjection/Compiler/DecoratorCompatibilityPass.php
@@ -1,0 +1,55 @@
+<?php
+
+/*
+ * This file is part of the Symfony package.
+ *
+ * (c) Fabien Potencier <fabien@symfony.com>
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Component\DependencyInjection\Compiler;
+
+use Symfony\Component\DependencyInjection\ContainerBuilder;
+use Symfony\Component\DependencyInjection\Alias;
+
+/**
+ * A copy of the decorator pass available in Symfony 2.5, to support 2.3 and 2.4.
+ *
+ * @author Christophe Coevoet <stof@notk.org>
+ * @author Fabien Potencier <fabien@symfony.com>
+ * @author Wouter J <wouter@wouterj.nl>
+ */
+class DecoratorCompatibilityPass implements CompilerPassInterface
+{
+    public function process(ContainerBuilder $container)
+    {
+        foreach ($container->getTaggedServiceIds('cmf_core.decorator') as $id => $tags) {
+            $inner = $tags[0]['decorates'];
+
+            if (isset($tags[0]['decoration_inner_name'])) {
+                $renamedId = $tags[0]['decoration_inner_name'];
+            } elseif (isset($tags[0]['decoration-inner-name'])) {
+                $renamedId = $tags[0]['decoration-inner-name'];
+            } else {
+                $renamedId = $id.'.inner';
+            }
+
+            // we create a new alias/service for the service we are replacing
+            // to be able to reference it in the new one
+            if ($container->hasAlias($inner)) {
+                $alias = $container->getAlias($inner);
+                $public = $alias->isPublic();
+                $container->setAlias($renamedId, new Alias((string) $alias, false));
+            } else {
+                $definition = $container->getDefinition($inner);
+                $public = $definition->isPublic();
+                $definition->setPublic(false);
+                $container->setDefinition($renamedId, $definition);
+            }
+
+            $container->setAlias($inner, new Alias($id, $public));
+        }
+    }
+}


### PR DESCRIPTION
CmfMenuBundle 2.0 will use decorators, which is only available since 2.5. This tag will be the BC layer for this feature until we drop 2.3 support, which will be in May 2016.

This PR needs some tests