### PR TITLE
Make lots of services private

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 Changelog
 =========
 
+* **2015-04-12**: [BC BREAK] The following services were made private: `cmf_core.admin_extension.child`, `cmf_core.security.publishable_voter`, `cmf_core.security.publish_time_period_voter`, `cmf_core.security.published_voter`, `cmf_core.admin_extension.publish_workflow.publishable`, `cmf_core.admin_extension.publish_workflow.time_period`, `cmf_core.twig.children_extension`, `cmf_core.templating.helper`, `cmf_core.persistence.phpcr.non_translatable_metadata_listener`, `cmf_core.persistence.phpcr.translatable_metadata_listener`, `cmf_core.admin_extension.translatable`
+* **2015-04-12**: The following services could not be private, but should be considered as such: `cmf_core.publish_workflow.request_listener`, `cmf_core.form.type.checkbox_url_label`
+
 1.2.0-RC1
 ---------
 

--- a/Resources/config/admin-phpcr.xml
+++ b/Resources/config/admin-phpcr.xml
@@ -10,7 +10,7 @@
 
     <services>
 
-        <service id="cmf_core.admin_extension.child" class="%cmf_core.admin_extension.child.class%">
+        <service id="cmf_core.admin_extension.child" class="%cmf_core.admin_extension.child.class%" public="false">
             <tag name="sonata.admin.extension"/>
         </service>
 

--- a/Resources/config/form-type.xml
+++ b/Resources/config/form-type.xml
@@ -8,6 +8,7 @@
     </parameters>
 
     <services>
+        <!-- This service can't be set to private, but has to be considered as such -->
         <service id="cmf_core.form.type.checkbox_url_label" class="%cmf_core.form.type.checkbox_url_label.class%">
             <tag name="form.type" alias="cmf_core_checkbox_url_label" />
             <argument type="service" id="router" />

--- a/Resources/config/publish-workflow.xml
+++ b/Resources/config/publish-workflow.xml
@@ -29,14 +29,15 @@
             <argument>%cmf_core.publish_workflow.view_non_published_role%</argument>
         </service>
 
-        <service id="cmf_core.security.publishable_voter" class="%cmf_core.security.publishable_voter.class%">
+        <service id="cmf_core.security.publishable_voter" class="%cmf_core.security.publishable_voter.class%" public="false">
             <tag name="cmf_published_voter" priority="10"/>
         </service>
 
-        <service id="cmf_core.security.publish_time_period_voter" class="%cmf_core.security.publish_time_period_voter.class%">
+        <service id="cmf_core.security.publish_time_period_voter" class="%cmf_core.security.publish_time_period_voter.class%" public="false">
             <tag name="cmf_published_voter" priority="20"/>
         </service>
 
+        <!-- This service can't be set to private, but has to be considered as such -->
         <service id="cmf_core.publish_workflow.request_listener" class="%cmf_core.publish_workflow.request_listener.class%">
             <argument type="service" id="cmf_core.publish_workflow.checker"/>
             <tag name="kernel.event_subscriber"/>
@@ -44,19 +45,19 @@
 
         <!-- integration with core security service -->
 
-        <service id="cmf_core.security.published_voter" class="%cmf_core.security.publishable_voter.class%">
+        <service id="cmf_core.security.published_voter" class="%cmf_core.security.publishable_voter.class%" public="false">
             <argument type="service" id="service_container" on-invalid="ignore"/>
             <tag name="security.voter"/>
         </service>
 
         <!-- integration with sonata admin - removed by the DI class if sonata is not available -->
 
-        <service id="cmf_core.admin_extension.publish_workflow.publishable" class="%cmf_core.admin_extension.publish_workflow.publishable.class%">
+        <service id="cmf_core.admin_extension.publish_workflow.publishable" class="%cmf_core.admin_extension.publish_workflow.publishable.class%" public="false">
             <argument>%cmf_core.sonata_admin.extension.publishable.form_group%</argument>
             <tag name="sonata.admin.extension"/>
         </service>
 
-        <service id="cmf_core.admin_extension.publish_workflow.time_period" class="%cmf_core.admin_extension.publish_workflow.time_period.class%">
+        <service id="cmf_core.admin_extension.publish_workflow.time_period" class="%cmf_core.admin_extension.publish_workflow.time_period.class%" public="false">
             <argument>%cmf_core.sonata_admin.extension.publish_time.form_group%</argument>
             <tag name="sonata.admin.extension"/>
         </service>

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -12,15 +12,16 @@
 
     <services>
 
-        <service id="cmf_core.twig.children_extension" class="%cmf_core.twig_extension.class%">
+        <service id="cmf_core.twig.children_extension" class="%cmf_core.twig_extension.class%" public="false">
             <argument type="service" id="cmf_core.templating.helper"/>
             <tag name="twig.extension"/>
         </service>
 
-        <service id="cmf_core.templating.helper" class="%cmf_core.templating.helper.class%">
+        <service id="cmf_core.templating.helper" class="%cmf_core.templating.helper.class%" public="false">
             <argument type="service" id="cmf_core.publish_workflow.checker" on-invalid="ignore"/>
             <argument type="service" id="doctrine_phpcr" on-invalid="ignore"/>
             <argument>%cmf_core.persistence.phpcr.manager_name%</argument>
+            <tag name="templating.helper" alias="cmf"/>
         </service>
 
     </services>

--- a/Resources/config/translatable-disabled.xml
+++ b/Resources/config/translatable-disabled.xml
@@ -11,7 +11,7 @@
 
     <services>
 
-        <service id="cmf_core.persistence.phpcr.non_translatable_metadata_listener" class="%cmf_core.persistence.phpcr.non_translatable_metadata_listener.class%">
+        <service id="cmf_core.persistence.phpcr.non_translatable_metadata_listener" class="%cmf_core.persistence.phpcr.non_translatable_metadata_listener.class%" public="false">
             <tag name="doctrine_phpcr.event_subscriber"/>
         </service>
 

--- a/Resources/config/translatable.xml
+++ b/Resources/config/translatable.xml
@@ -11,12 +11,12 @@
 
     <services>
 
-        <service id="cmf_core.persistence.phpcr.translatable_metadata_listener" class="%cmf_core.persistence.phpcr.translatable_metadata_listener.class%">
+        <service id="cmf_core.persistence.phpcr.translatable_metadata_listener" class="%cmf_core.persistence.phpcr.translatable_metadata_listener.class%" public="false">
             <argument>%cmf_core.persistence.phpcr.translation_strategy%</argument>
             <tag name="doctrine_phpcr.event_subscriber"/>
         </service>
 
-        <service id="cmf_core.admin_extension.translatable" class="%cmf_core.admin_extension.translatable.class%">
+        <service id="cmf_core.admin_extension.translatable" class="%cmf_core.admin_extension.translatable.class%" public="false">
             <argument>%cmf_core.multilang.locales%</argument>
             <argument>%cmf_core.sonata_admin.extension.translatable.form_group%</argument>
             <tag name="sonata.admin.extension"/>

--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,8 @@
     "require-dev": {
         "symfony-cmf/routing-bundle": "~1.2",
         "symfony-cmf/testing": "~1.1",
-        "sonata-project/admin-bundle": "~2.2"
+        "sonata-project/admin-bundle": "~2.2",
+        "doctrine/dbal": "2.5.*"
     },
     "suggest": {
         "symfony/twig-bundle": "To get access to the CMF twig extension, ~2.1",


### PR DESCRIPTION
All these services aren't created for public usage. By making them private, they'll be removed during compilation time once no other service depends on it and if only one service depends on it, initialization will be inlined. Both improve the container performance.

Besides this, it has also become a best practice.