### PR TITLE
Removed deprecation notices

### DIFF
--- a/Form/Type/CheckboxUrlLabelFormType.php
+++ b/Form/Type/CheckboxUrlLabelFormType.php
@@ -16,6 +16,7 @@ use Symfony\Component\Routing\Generator\UrlGeneratorInterface;
 use Symfony\Component\Form\AbstractType;
 use Symfony\Component\Form\FormView;
 use Symfony\Component\Form\FormInterface;
+use Symfony\Component\OptionsResolver\OptionsResolver;
 use Symfony\Component\OptionsResolver\OptionsResolverInterface;
 
 /**
@@ -67,6 +68,11 @@ class CheckboxUrlLabelFormType extends AbstractType
      * {@inheritDoc}
      */
     public function setDefaultOptions(OptionsResolverInterface $resolver)
+    {
+        $this->configureOptions($resolver);
+    }
+
+    public function configureOptions(OptionsResolver $resolver)
     {
         $resolver->setDefaults(array(
             'routes' => array(),

--- a/PublishWorkflow/PublishWorkflowChecker.php
+++ b/PublishWorkflow/PublishWorkflowChecker.php
@@ -139,14 +139,13 @@ class PublishWorkflowChecker implements SecurityContextInterface
             $attributes = array($attributes);
         }
 
-        $tokenStorage = null;
-        $authorizationChecker = null;
+        $tokenStorage = $authorizationChecker = null;
         if ($this->container->has('security.token_storage')) {
             $tokenStorage = $this->container->get('security.token_storage');
             $authorizationChecker = $this->container->get('security.authorization_checker');
         } elseif ($this->container->has('security.context')) {
             // to be BC with Symfony <2.6
-            $authoriationChecker = $tokenStorage = $this->container->get('security.context');
+            $authorizationChecker = $tokenStorage = $this->container->get('security.context');
         }
 
         if ((count($attributes) === 1)

--- a/Security/Authorization/Voter/PublishedVoter.php
+++ b/Security/Authorization/Voter/PublishedVoter.php
@@ -17,7 +17,7 @@ use Symfony\Component\Security\Core\Authorization\Voter\VoterInterface;
 use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishWorkflowChecker;
 
 /**
- * This is a security voter registered with the Symfony security.context that
+ * This is a security voter registered with the Symfony security system that
  * brings the publish workflow into standard Symfony security.
  *
  * @author David Buchmann <mail@davidbu.ch>

--- a/Tests/Resources/app/config/routing.yml
+++ b/Tests/Resources/app/config/routing.yml
@@ -1,5 +1,5 @@
 home:
-    pattern: /
+    path: /
 
 hello:
-    pattern: /hello/{name}
+    path: /hello/{name}

--- a/Tests/Unit/Form/CheckboxUrlLabelFormTypeTest.php
+++ b/Tests/Unit/Form/CheckboxUrlLabelFormTypeTest.php
@@ -12,7 +12,7 @@
 namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Unit\Form;
 
 use Symfony\Component\Form\AbstractExtension;
-use Symfony\Component\Form\Tests\Extension\Core\Type\TypeTestCase;
+use Symfony\Component\Form\Test\TypeTestCase;
 use Symfony\Cmf\Bundle\CoreBundle\Form\Type\CheckboxUrlLabelFormType;
 use Symfony\Component\Routing\RequestContext;
 use Symfony\Component\Routing\RouterInterface;

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,8 @@
         "symfony/framework-bundle": "~2.3"
     },
     "require-dev": {
+        "symfony/security-bundle": "~2.1",
+        "mockery/mockery": "0.9.*",
         "symfony-cmf/routing-bundle": "~1.2",
         "symfony-cmf/testing": "~1.1",
         "sonata-project/admin-bundle": "~2.2",


### PR DESCRIPTION
This PR has removed all deprecation notices from the CoreBundle code base. BC is kept to support Symfony 2.3 and the tests aren't updated for the security.context change. After this PR, the user will no longer see any deprecation notices of the CoreBundle in the web dev toolbar.