### PR TITLE
using setter injection to avoid cyclic dependencies and be more lazy

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -26,7 +26,7 @@ matrix:
     - php: 5.6
       env: SYMFONY_VERSION=3.0.*
     - php: 5.3
-      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest"
+      env: SYMFONY_VERSION=2.3.* COMPOSER_FLAGS="--prefer-lowest" SYMFONY_DEPRECATIONS_HELPER=weak
   allow_failures:
     - php: nightly
     - env: SYMFONY_VERSION=2.8.*

--- a/DependencyInjection/CmfCoreExtension.php
+++ b/DependencyInjection/CmfCoreExtension.php
@@ -269,7 +269,10 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
             $container->setParameter($this->getAlias() . '.persistence.phpcr.basepath', $config['persistence']['phpcr']['basepath']);
 
             $templatingHelper = $container->getDefinition($this->getAlias() . '.templating.helper');
-            $templatingHelper->replaceArgument(1, new Reference($config['persistence']['phpcr']['manager_registry']));
+            $templatingHelper->addMethodCall('setDoctrineRegistry', array(
+                new Reference($config['persistence']['phpcr']['manager_registry']),
+                '%cmf_core.persistence.phpcr.manager_name%'
+            ));
 
             if ($config['persistence']['phpcr']['use_sonata_admin']) {
                 $this->loadSonataPhpcrAdmin($config, $loader, $container);

--- a/Resources/config/services.xml
+++ b/Resources/config/services.xml
@@ -19,8 +19,6 @@
 
         <service id="cmf_core.templating.helper" class="%cmf_core.templating.helper.class%" public="false">
             <argument type="service" id="cmf_core.publish_workflow.checker" on-invalid="ignore"/>
-            <argument type="service" id="doctrine_phpcr" on-invalid="ignore"/>
-            <argument>%cmf_core.persistence.phpcr.manager_name%</argument>
             <tag name="templating.helper" alias="cmf"/>
         </service>
 


### PR DESCRIPTION
fix #163

use setter injection. also only get doctrine from the registry when we actually need it. not sure why this was previously done eager.