### PR TITLE
a filter for publish workflow on queries

### DIFF
--- a/Doctrine/Phpcr/PublishWorkflowQueryFilter.php
+++ b/Doctrine/Phpcr/PublishWorkflowQueryFilter.php
@@ -1,0 +1,154 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Doctrine\Phpcr;
+
+use Doctrine\Common\EventSubscriber;
+use Doctrine\Common\Persistence\Event\LoadClassMetadataEventArgs;
+use Doctrine\ODM\PHPCR\DocumentManager;
+use Doctrine\ODM\PHPCR\Mapping\ClassMetadata;
+use Doctrine\ODM\PHPCR\Query\Builder\AbstractNode;
+use Doctrine\ODM\PHPCR\Query\Builder\From;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceDocument;
+use Doctrine\ODM\PHPCR\Query\Builder\SourceJoin;
+use Doctrine\ODM\PHPCR\Query\Query;
+use PHPCR\Query\QueryInterface;
+
+/**
+ * Tool to filter queries to only find published documents.
+ *
+ * This only work for the known voters publishable and time period.
+ *
+ * @author David Buchmann <mail@davidbu.ch>
+ */
+class PublishWorkflowQueryFilter
+{
+    private $skipClasses = array();
+
+    /**
+     * Hashmap of FQN => field configuration as per configureFields().
+     *
+     * @var array
+     */
+    private $fieldMap = array();
+
+    /**
+     * Mark a class to be skipped from filtering
+     *
+     * @param string $class FQN
+     */
+    public function skipClass($class)
+    {
+        $this->skipClasses[$class] = true;
+    }
+
+    /**
+     * The default map if not set for a specific class is
+     *
+     * publishable => publishable
+     * publishStartDate => publishStartDate
+     * publishEndDate => publishEndDate
+     *
+     * @param string $class FQN
+     * @param array  $map   Hashmap with the field names to use for filtering
+     */
+    public function configureFields($class, array $map)
+    {
+        $this->fieldMap[$class] = $map;
+    }
+
+    /**
+     * Update query to limit results to published documents.
+     *
+     * @param QueryBuilder $queryBuilder
+     */
+    public function filterQuery(QueryBuilder $queryBuilder)
+    {
+        /** @var From $from */
+        $from = $queryBuilder->getChildOfType(AbstractNode::NT_FROM);
+        $map = $this->extractAlias($from);
+        foreach ($map as $alias => $options) {
+            if (isset($this->skipClasses[$options['class']])) {
+                continue;
+            }
+
+            if ($options['publishable']) {
+                $queryBuilder
+                    ->andWhere()
+                        ->eq()
+                            ->field($this->getFieldName('publishable', $alias, $options))
+                            ->literal(true)
+                ;
+            }
+
+            if ($options['publish_time_period']) {
+                $queryBuilder
+                    ->andWhere()
+                    ->andX()
+                        ->orX()
+                            // TODO how to check for IS NULL?
+                            ->not()->fieldIsset($this->getFieldName('publishStartDate', $alias, $options))->end()
+                            ->lte()
+                                ->field($this->getFieldName('publishStartDate', $alias, $options))
+                                ->literal(new \DateTime())
+                            ->end()
+                        ->end()
+                    ->andX()
+                        ->orX()
+                            ->not()->fieldIsset($this->getFieldName('publishEndDate', $alias, $options))->end()
+                            ->gte()
+                                ->field($this->getFieldName('publishEndDate', $alias, $options))
+                                ->literal(new \DateTime())
+                            ->end()
+                        ->end()
+                    ->end()
+                ;
+            }
+        }
+    }
+
+    private function extractAlias(AbstractNode $source)
+    {
+        if ($source instanceof SourceDocument) {
+            $class = $source->getDocumentFqn();
+            return array(
+                $source->getAlias() => array(
+                    'class' => $class,
+                    'publishable' => is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface'),
+                    'publish_time_period' => is_subclass_of($class, 'Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface'),
+                )
+            );
+        }
+
+        if ($source instanceof From) {
+            return $this->extractAlias($source->getChildOfType(AbstractNode::NT_SOURCE));
+        }
+
+        if (!$source instanceof SourceJoin) {
+            throw new \Exception(sprintf('Source of class %s is not implemented', get_class($source)));
+        }
+
+        $map = $this->extractAlias($source->getChildOfType(AbstractNode::NT_SOURCE_JOIN_LEFT));
+        return array_merge(
+            $map,
+            $this->extractAlias($source->getChildOfType(AbstractNode::NT_SOURCE_JOIN_RIGHT))
+        );
+    }
+
+    private function getFieldName($field, $alias, $options)
+    {
+        return $alias.'.'.(isset($this->fieldMap[$options['class']][$field])
+            ? $this->fieldMap[$options['class']][$field]
+            : $field
+        );
+    }
+}

--- a/Tests/Functional/PublishWorkflow/QueryFilterTest.php
+++ b/Tests/Functional/PublishWorkflow/QueryFilterTest.php
@@ -1,0 +1,87 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Functional\Form;
+
+use Doctrine\ODM\PHPCR\DocumentManagerInterface;
+use Doctrine\ODM\PHPCR\Query\Builder\QueryBuilder;
+use Symfony\Cmf\Bundle\CoreBundle\Doctrine\Phpcr\PublishWorkflowQueryFilter;
+use Symfony\Cmf\Component\Testing\Functional\BaseTestCase;
+
+class QueryFilterTest extends BaseTestCase
+{
+    /**
+     * @var QueryBuilder
+     */
+    private $qb;
+
+    private $documentClass = 'Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\Document\Publishable';
+
+    public function setUp()
+    {
+        $this->db('PHPCR')->loadFixtures(array('\Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\DataFixture\LoadPublishableData'));
+
+        /** @var DocumentManagerInterface $dm */
+        $dm = $this->db('PHPCR')->getOm();
+        $this->qb = $dm->createQueryBuilder();
+        $this->qb->fromDocument($this->documentClass, 'a');
+        $documents = $this->qb->getQuery()->getResult();
+        $this->assertCount(3, $documents);
+
+        $this->assertTrue(isset($documents['/published']));
+        $this->assertTrue(isset($documents['/unpublishable']));
+        $this->assertTrue(isset($documents['/timeperiod']));
+    }
+
+    public function testQueryFilter()
+    {
+        $filter = new PublishWorkflowQueryFilter();
+//        $filter->filterQuery($this->qb);
+        $this->qb
+            ->where()
+            ->lte()
+            ->field('a.publishStartDate')
+            ->literal(new \DateTime());
+var_dump($this->qb->getQuery()->getStatement());
+        $documents = $this->qb->getQuery()->getResult();
+        $this->assertCount(1, $documents);
+var_dump(array_keys($documents->toArray()));
+        $this->assertTrue(isset($documents['/published']));
+    }
+
+    public function testSkip()
+    {
+        $filter = new PublishWorkflowQueryFilter();
+        $filter->skipClass($this->documentClass);
+        $filter->filterQuery($this->qb);
+        $documents = $this->qb->getQuery()->getResult();
+        $this->assertCount(3, $documents);
+
+        $this->assertTrue(isset($documents['/published']));
+        $this->assertTrue(isset($documents['/unpublishable']));
+        $this->assertTrue(isset($documents['/timeperiod']));
+    }
+
+    /**
+     * This test is relying on the fact that publish start date may be null
+     */
+    public function testMap()
+    {
+        $filter = new PublishWorkflowQueryFilter();
+        $filter->configureFields($this->documentClass, array('publishStartDate' => 'foo'));
+        $filter->filterQuery($this->qb);
+        $documents = $this->qb->getQuery()->getResult();
+        $this->assertCount(2, $documents);
+
+        $this->assertTrue(isset($documents['/published']));
+        $this->assertTrue(isset($documents['/timeperiod']));
+    }
+}

--- a/Tests/Resources/DataFixture/LoadPublishableData.php
+++ b/Tests/Resources/DataFixture/LoadPublishableData.php
@@ -1,0 +1,44 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\DataFixture;
+
+use Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\Document\Publishable;
+use Symfony\Cmf\Bundle\RoutingBundle\Doctrine\Phpcr\Route;
+
+use Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\Document\Content;
+
+use Doctrine\Common\DataFixtures\FixtureInterface;
+use Doctrine\Common\Persistence\ObjectManager;
+use Doctrine\ODM\PHPCR\Document\Generic;
+
+/**
+ * Fixtures class for test data.
+ */
+class LoadPublishableData implements FixtureInterface
+{
+    public function load(ObjectManager $manager)
+    {
+        $doc = new Publishable(true, new \DateTime('yesterday'));
+        $doc->id = '/published';
+        $manager->persist($doc);
+
+        $doc = new Publishable(false);
+        $doc->id = '/unpublishable';
+        $manager->persist($doc);
+
+        $doc = new Publishable(true, new \DateTime('tomorrow'));
+        $doc->id = '/timeperiod';
+        $manager->persist($doc);
+
+        $manager->flush();
+    }
+}

--- a/Tests/Resources/Document/Publishable.php
+++ b/Tests/Resources/Document/Publishable.php
@@ -1,0 +1,65 @@
+<?php
+
+/*
+ * This file is part of the Symfony CMF package.
+ *
+ * (c) 2011-2014 Symfony CMF
+ *
+ * For the full copyright and license information, please view the LICENSE
+ * file that was distributed with this source code.
+ */
+
+namespace Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\Document;
+
+use Doctrine\ODM\PHPCR\Mapping\Annotations as PHPCR;
+
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishableReadInterface;
+use Symfony\Cmf\Bundle\CoreBundle\PublishWorkflow\PublishTimePeriodReadInterface;
+
+/**
+ * @PHPCR\Document(referenceable=true)
+ */
+class Publishable implements PublishableReadInterface, PublishTimePeriodReadInterface
+{
+    /** @PHPCR\Id */
+    public $id;
+
+    /** @PHPCR\Field(type="boolean") */
+    private $publishable;
+
+    /** @PHPCR\Field(type="date", nullable=true) */
+    private $publishStartDate;
+
+    /** @PHPCR\Field(type="date", nullable=true) */
+    private $publishEndDate;
+
+    /** @PHPCR\Field(type="date", nullable=true) */
+    private $foo;
+
+    public function __construct($publishable = true, $start = null, $end = null)
+    {
+        $this->publishable = $publishable;
+        $this->publishStartDate = $start;
+        $this->publishEndDate = $end;
+    }
+
+    public function getId()
+    {
+        return $this->id;
+    }
+
+    public function isPublishable()
+    {
+        return $this->publishable;
+    }
+
+    public function getPublishStartDate()
+    {
+        return $this->publishStartDate;
+    }
+
+    public function getPublishEndDate()
+    {
+        return $this->publishEndDate;
+    }
+}


### PR DESCRIPTION
fix #126

you have to call the filter manually as there is no event or filter system like with the ORM. 

for now it only works with the ODM query builder. not with phpcr query builder or sql2. we don't have a DQL, right?

something is wrong with the publishStartDate query but i did not find out what. i reduced it to this but still did not work:

```
SELECT * 
FROM [nt:unstructured] AS a 
WHERE (
    a.publishStartDate <= CAST('2015-08-25T20:23:44.000+02:00' AS DATE) 
   AND (a.[phpcr:class] = 'Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\Document\Publishable' 
         OR a.[phpcr:classparents] = 'Symfony\Cmf\Bundle\CoreBundle\Tests\Resources\Document\Publishable'
    )
)
```

i checked the sqlite database and for the /published document, the property is
```
<sv:property sv:name="publishStartDate" sv:type="Date" sv:multi-valued="0">
    <sv:value length="29">2015-08-23T22:00:00.000+00:00</sv:value>
</sv:property>
```