### PR TITLE
Do not append SimpleCmsBundle basepath to RoutingBundle

### DIFF
--- a/DependencyInjection/CmfCoreExtension.php
+++ b/DependencyInjection/CmfCoreExtension.php
@@ -118,9 +118,6 @@ class CmfCoreExtension extends Extension implements PrependExtensionInterface
                         break;
                     case 'cmf_routing':
                         $routePaths = array($persistenceConfig['basepath'].'/routes');
-                        if (isset($extensions['cmf_simple_cms'])) {
-                            $routePaths[] = $persistenceConfig['basepath'].'/simple';
-                        }
                         $prependConfig = array(
                             'dynamic' => array(
                                 'enabled' => true,


### PR DESCRIPTION
The bundles already take care of this themselves.

In the current situation, `/cms/simple` will *always* be created, even when the basepath for `CmfSimpleCmsBundle` is configured to something different.