### PR TITLE
Save services to improve performance

### DIFF
--- a/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
+++ b/Tests/Unit/PublishWorkflow/PublishWorkflowCheckerTest.php
@@ -66,6 +66,7 @@ class PublishWorkflowCheckerTest extends \PHPUnit_Framework_TestCase
         // assuming Symfony <2.6
         $this->container->shouldReceive('has')->with('security.context')->andReturn(true);
         $this->container->shouldReceive('has')->with('security.token_storage')->andReturn(false);
+        $this->container->shouldReceive('has')->with('security.authorization_checker')->andReturn(false);
     }
 
     protected function tearDown()
@@ -159,6 +160,7 @@ class PublishWorkflowCheckerTest extends \PHPUnit_Framework_TestCase
         $container->shouldReceive('get')->with('security.token_storage')->andReturn($ts);
         $container->shouldReceive('get')->with('security.authorization_checker')->andReturn($ac);
         $container->shouldReceive('has')->with('security.token_storage')->andReturn(true);
+        $container->shouldReceive('has')->with('security.authorization_checker')->andReturn(true);
 
         $ts->shouldReceive('getToken')->andReturn($token);
         $ac->shouldReceive('isGranted')->with($this->role)->andReturn(true);


### PR DESCRIPTION
`PublishWorkflowChecker#isGranted()` is executed quite often during a normal request (99 times for Sandbox home). `Container#get()` requests are quite expensive. Only calling this one twice per request instead of 202 times improves the performance.

As a bonus, we'll need less code changes to drop 2.3 compat.