### PR TITLE
Allow RC instead of dev of slugifier-api

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -14,7 +14,7 @@
     "require": {
         "php": "^5.3.9|^7.0",
         "symfony/framework-bundle": "^2.3",
-        "symfony-cmf/slugifier-api": "^1.0@dev"
+        "symfony-cmf/slugifier-api": "^1.0@rc"
     },
     "require-dev": {
         "symfony/security-bundle": "^2.1",


### PR DESCRIPTION
I just released 1.0.0-RC1.